### PR TITLE
Ship deterministic static assets in 0.37.0

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,45 @@
+name: Core library
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web:
+    name: Web (${{ matrix.os }}, Crystal ${{ matrix.crystal }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        crystal:
+          - "1.10.1"
+          - latest
+
+    steps:
+      - name: Check out the library
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Run the complete web suite
+        run: make test-web
+
+      - name: Confirm tests did not change tracked files
+        run: git diff --exit-code

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -43,3 +43,19 @@ jobs:
 
       - name: Confirm tests did not change tracked files
         run: git diff --exit-code
+
+  windows-static-assets:
+    name: Static assets (Windows, Crystal latest)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out the library
+        uses: actions/checkout@v4
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
+
+      - name: Run the static asset compiler contract
+        run: crystal spec spec/web/asset_pipeline/static_assets_spec.cr

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Asset Pipeline now covers two related jobs for Crystal applications:
 
-1. a legacy web asset pipeline for import maps, JavaScript, and static assets
+1. a production web asset compiler for import maps, JavaScript, styles, images,
+   fonts, and other application-owned files
 2. a native UI and host-integration layer for Apple platforms, with HIG-driven
    validation for macOS and iOS
 3. a web-first design-system proof with semantic tokens, opinionated
@@ -25,7 +26,7 @@ Add the shard to your `shard.yml`:
 dependencies:
   asset_pipeline:
     github: amberframework/asset_pipeline
-    version: 0.36.0
+    version: 0.37.0
 ```
 
 Then run:
@@ -56,6 +57,35 @@ Current native work includes:
 
 The original FrontLoader flow is still here for import maps and web assets.
 That part of the shard remains useful, but it is no longer the whole story.
+
+### Application Static Assets
+
+Amber V2 applications author files under `app/assets/` and compile them into
+`public/assets/`. Every emitted file is named from its SHA-256 content digest,
+including images, fonts, documents, WebAssembly, and other static files. CSS
+and JavaScript references to local dependencies are rewritten to the compiled
+URLs, and compressible files receive deterministic `.gz` siblings.
+
+```crystal
+require "asset_pipeline"
+
+compiler = AssetPipeline::StaticAssets::Compiler.new(
+  source_root: "app/assets",
+  output_root: "public/assets",
+  public_path: "/assets"
+)
+
+manifest = compiler.build
+puts manifest.path("images/logo.svg")
+puts manifest.integrity("stylesheets/app.css")
+```
+
+The manifest is written last, so a failed build cannot replace the last valid
+release contract. Use `compiler.check` (or
+`AssetPipeline::StaticAssets::Compiler.check(output_root: "public/assets")`)
+in deployment validation to detect missing, modified, or incorrectly
+precompressed output. Only files named by the prior manifest are pruned;
+unrelated files beneath `public/` are not deleted.
 
 ### Web Design System
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: asset_pipeline
-version: 0.36.0
+version: 0.37.0
 
 authors:
   - Seth Tucker <crimsonknightstudios@gmail.com>

--- a/spec/web/asset_pipeline/static_assets_spec.cr
+++ b/spec/web/asset_pipeline/static_assets_spec.cr
@@ -1,0 +1,236 @@
+require "../spec_helper"
+require "../../../src/asset_pipeline/static_assets"
+
+private def with_static_asset_fixture(&)
+  root = Path[Dir.tempdir].join("asset-pipeline-static-assets-#{Random::Secure.hex(8)}")
+  source = root.join("app/assets")
+  output = root.join("public/assets")
+  Dir.mkdir_p(source.join("stylesheets/nested"))
+  Dir.mkdir_p(source.join("stylesheets/images"))
+  Dir.mkdir_p(source.join("javascript/modules"))
+  Dir.mkdir_p(source.join("images/nested/a"))
+  Dir.mkdir_p(source.join("images/nested/b"))
+  Dir.mkdir_p(source.join("fonts"))
+  Dir.mkdir_p(source.join("files"))
+
+  File.write(source.join("images/logo.svg"), %(<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h2v2z"/></svg>))
+  File.write(source.join("images/photo.webp"), Bytes[0x52, 0x49, 0x46, 0x46])
+  File.write(source.join("images/photo.avif"), Bytes[0x00, 0x00, 0x00, 0x18])
+  File.write(source.join("images/nested/a/icon.svg"), %(<svg><title>A</title></svg>))
+  File.write(source.join("images/nested/b/icon.svg"), %(<svg><title>B</title></svg>))
+  File.write(source.join("images/space name.svg"), %(<svg><title>Space</title></svg>))
+  File.write(source.join("stylesheets/images/local.png"), Bytes[0x89, 0x50, 0x4e, 0x47])
+  File.write(source.join("fonts/inter.woff"), Bytes[0x77, 0x4f, 0x46, 0x46])
+  File.write(source.join("fonts/inter.woff2"), Bytes[0x77, 0x4f, 0x46, 0x32])
+  File.write(source.join("fonts/.gitkeep"), "")
+  Dir.mkdir_p(source.join(".private"))
+  File.write(source.join(".private/secret.txt"), "not public")
+  File.write(source.join("files/terms.pdf"), Bytes[0x25, 0x50, 0x44, 0x46])
+  File.write(source.join("site.webmanifest"), %({"name":"Amber"}))
+  File.write(source.join("stylesheets/reset.css"), "body { margin: 0; }\n")
+  File.write(source.join("stylesheets/nested/admin.css"), ".mark { background: url('../../images/nested/a/icon.svg#mark'); }\n")
+  File.write(source.join("stylesheets/adversarial.css"), <<-CSS)
+    /* url('../images/comment-missing.svg') */
+    .copy::before { content: "url('../images/string-missing.svg')"; }
+    CSS
+  File.write(source.join("stylesheets/app.css"), <<-CSS)
+    @import "reset.css";
+    @font-face { font-family: Inter; src: url('../fonts/inter.woff2') format('woff2'); }
+    .brand { background: url('../images/logo.svg?theme=amber#mark'); }
+    .local { background: url('images/local.png'); }
+    .external { background: url('https://example.test/remote.svg'); }
+    .inline { background: url(data:image/svg+xml;base64,AAAA); }
+    /* url('../images/comment-missing.svg') */
+    .copy::before { content: "url('../images/string-missing.svg')"; }
+    CSS
+  File.write(source.join("javascript/modules/pet.js"), "export const pet = 'Amber';\n")
+  File.write(source.join("javascript/adversarial.js"), <<-JS)
+    const example = "import './missing-string.js'";
+    // import "./missing-comment.js";
+    /* export { missing } from "./missing-block.js"; */
+    JS
+  File.write(source.join("javascript/app.js.map"), %({"version":3,"sources":["app.js"]}))
+  File.write(source.join("javascript/app.js"), <<-JS)
+    import { pet } from "./modules/pet.js";
+    import "lit";
+    export { pet } from './modules/pet.js';
+    const lazy = import("./modules/pet.js");
+    const example = "import './missing-string.js'";
+    // import "./missing-comment.js";
+    /* export { missing } from "./missing-block.js"; */
+    //# sourceMappingURL=app.js.map
+    JS
+
+  begin
+    yield source, output, root
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+describe AssetPipeline::StaticAssets::Compiler do
+  it "fingerprints every asset, preserves nested paths, records MIME/SRI, and writes deterministic gzip output" do
+    with_static_asset_fixture do |source, output, _root|
+      compiler = AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output)
+      manifest = compiler.build
+
+      manifest.assets.size.should eq(19)
+      manifest.assets.has_key?("fonts/.gitkeep").should be_false
+      manifest.assets.has_key?(".private/secret.txt").should be_false
+      manifest.path("images/logo.svg").should match(%r{\A/assets/images/logo-[a-f0-9]{32}\.svg\z})
+      manifest.path("images/nested/a/icon.svg").should_not eq(manifest.path("images/nested/b/icon.svg"))
+      manifest.path("images/space name.svg").should contain("space%20name-")
+      manifest.entry("images/photo.webp").content_type.should eq("image/webp")
+      manifest.entry("images/photo.avif").content_type.should eq("image/avif")
+      manifest.entry("fonts/inter.woff").content_type.should eq("font/woff")
+      manifest.entry("fonts/inter.woff2").content_type.should eq("font/woff2")
+      manifest.entry("site.webmanifest").content_type.should eq("application/manifest+json; charset=utf-8")
+      webmanifest_path = output.join(URI.decode(manifest.path("site.webmanifest").sub("/assets/", "")))
+      File.file?("#{webmanifest_path}.gz").should be_true
+      manifest.integrity("images/logo.svg").should match(/\Asha256-[A-Za-z0-9+\/]+={0,2}\z/)
+      manifest.entry("images/logo.svg").digest.size.should eq(64)
+
+      css_disk_path = output.join(manifest.path("stylesheets/app.css").sub("/assets/", ""))
+      File.exists?(css_disk_path).should be_true
+      File.exists?("#{css_disk_path}.gz").should be_true
+      File.read(css_disk_path).should contain(manifest.path("images/logo.svg") + "?theme=amber#mark")
+      File.read(css_disk_path).should contain(manifest.path("fonts/inter.woff2"))
+      File.read(css_disk_path).should contain(manifest.path("stylesheets/images/local.png"))
+      File.read(css_disk_path).should contain("https://example.test/remote.svg")
+      File.read(css_disk_path).should contain("data:image/svg+xml;base64,AAAA")
+      File.read(css_disk_path).should contain(%(/* url('../images/comment-missing.svg') */))
+      File.read(css_disk_path).should contain(%(content: "url('../images/string-missing.svg')"))
+
+      js_disk_path = output.join(manifest.path("javascript/app.js").sub("/assets/", ""))
+      File.read(js_disk_path).should contain(manifest.path("javascript/modules/pet.js"))
+      File.read(js_disk_path).should contain(manifest.path("javascript/app.js.map"))
+      File.read(js_disk_path).should contain(%(import "lit";))
+      File.read(js_disk_path).should contain(%(const example = "import './missing-string.js'";))
+      File.read(js_disk_path).should contain(%(// import "./missing-comment.js";))
+      File.read(js_disk_path).should contain(%(/* export { missing } from "./missing-block.js"; */))
+
+      ["stylesheets/adversarial.css", "javascript/adversarial.js"].each do |logical|
+        emitted_path = output.join(URI.decode(manifest.path(logical).sub("/assets/", "")))
+        File.read(emitted_path).should eq(File.read(source.join(logical)))
+      end
+
+      first_json = File.read(output.join("manifest.json"))
+      first_gzip = File.read(css_disk_path.to_s + ".gz").to_slice.dup
+      compiler.build
+      File.read(output.join("manifest.json")).should eq(first_json)
+      File.read(css_disk_path.to_s + ".gz").to_slice.should eq(first_gzip)
+      compiler.check.path("images/logo.svg").should eq(manifest.path("images/logo.svg"))
+
+      File.write(css_disk_path.to_s + ".gz", "corrupt gzip")
+      expect_raises(AssetPipeline::StaticAssets::VerificationError, /Precompressed static asset is invalid/) do
+        compiler.check
+      end
+    end
+  end
+
+  it "propagates dependency changes into CSS fingerprints and safely prunes only prior manifest-owned files" do
+    with_static_asset_fixture do |source, output, _root|
+      keep = output.join("keep-me.txt")
+      Dir.mkdir_p(output)
+      File.write(keep, "application-owned")
+
+      compiler = AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output)
+      first = compiler.build
+      old_logo = first.path("images/logo.svg")
+      old_css = first.path("stylesheets/app.css")
+
+      File.write(source.join("images/logo.svg"), %(<svg><title>Changed</title></svg>))
+      second = compiler.build
+
+      second.path("images/logo.svg").should_not eq(old_logo)
+      second.path("stylesheets/app.css").should_not eq(old_css)
+      File.exists?(keep).should be_true
+      File.exists?(output.join(old_logo.sub("/assets/", ""))).should be_false
+      File.exists?(output.join(old_css.sub("/assets/", ""))).should be_false
+    end
+  end
+
+  it "reloads the manifest and keeps lookups strict" do
+    with_static_asset_fixture do |source, output, _root|
+      built = AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output).build
+      loaded = AssetPipeline::StaticAssets::Manifest.load(output.join("manifest.json"))
+
+      loaded.path("images/logo.svg").should eq(built.path("images/logo.svg"))
+      loaded.integrity("images/logo.svg").should eq(built.integrity("images/logo.svg"))
+      expect_raises(AssetPipeline::StaticAssets::MissingAssetError, /not present in the compiled manifest/) do
+        loaded.path("images/missing.svg")
+      end
+
+      emitted_logo = output.join(loaded.path("images/logo.svg").sub("/assets/", ""))
+      File.write(emitted_logo, "tampered")
+      expect_raises(AssetPipeline::StaticAssets::VerificationError, /byte count changed|digest changed/) do
+        loaded.verify(output)
+      end
+    end
+  end
+
+  it "wraps manifest schema errors in the static-asset error contract" do
+    with_static_asset_fixture do |_source, output, _root|
+      Dir.mkdir_p(output)
+      File.write(output.join("manifest.json"), %({"schema_version":"wrong","public_path":"/assets","assets":{}}))
+      expect_raises(AssetPipeline::StaticAssets::ConfigurationError, /does not match schema/) do
+        AssetPipeline::StaticAssets::Manifest.load(output.join("manifest.json"))
+      end
+    end
+  end
+
+  it "preserves the prior valid build when compilation fails" do
+    with_static_asset_fixture do |source, output, _root|
+      compiler = AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output)
+      first = compiler.build
+      manifest_json = File.read(output.join("manifest.json"))
+      emitted_paths = first.assets.values.map do |entry|
+        output.join(URI.decode(entry.path.sub("/assets/", "")))
+      end
+
+      File.write(source.join("stylesheets/app.css"), ".missing { background: url('missing.png'); }")
+      expect_raises(AssetPipeline::StaticAssets::InvalidReferenceError) do
+        compiler.build
+      end
+
+      File.read(output.join("manifest.json")).should eq(manifest_json)
+      emitted_paths.each { |path| File.file?(path).should be_true }
+      AssetPipeline::StaticAssets::Compiler.check(output_root: output).assets.should eq(first.assets)
+    end
+  end
+
+  it "reports missing and out-of-root references with the referring asset" do
+    with_static_asset_fixture do |source, output, _root|
+      File.write(source.join("stylesheets/app.css"), ".bad { background: url('../images/missing.svg'); }")
+      error = expect_raises(AssetPipeline::StaticAssets::InvalidReferenceError) do
+        AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output).build
+      end
+      error.message.to_s.should contain("stylesheets/app.css")
+      error.message.to_s.should contain("images/missing.svg")
+
+      File.write(source.join("stylesheets/app.css"), ".bad { background: url('../../../outside.svg'); }")
+      expect_raises(AssetPipeline::StaticAssets::InvalidReferenceError, /escapes source root/) do
+        AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output).build
+      end
+    end
+  end
+
+  it "rejects output nested in source and symlinks that escape source root" do
+    with_static_asset_fixture do |source, output, root|
+      expect_raises(AssetPipeline::StaticAssets::ConfigurationError, /must not be inside source root/) do
+        AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: source.join("compiled"))
+      end
+
+      outside = root.join("outside.svg")
+      File.write(outside, "outside")
+      File.symlink(outside, source.join("images/escape.svg"))
+      expect_raises(AssetPipeline::StaticAssets::ConfigurationError, /symlink escapes source root/) do
+        AssetPipeline::StaticAssets::Compiler.new(source_root: source, output_root: output).build
+      end
+    end
+  end
+
+  it "is exposed by the top-level asset_pipeline require" do
+    AssetPipeline::StaticAssets::MANIFEST_SCHEMA_VERSION.should eq(1)
+  end
+end

--- a/spec/web/asset_pipeline/static_assets_spec.cr
+++ b/spec/web/asset_pipeline/static_assets_spec.cr
@@ -1,4 +1,5 @@
-require "../spec_helper"
+require "spec"
+require "file_utils"
 require "../../../src/asset_pipeline/static_assets"
 
 private def with_static_asset_fixture(&)

--- a/spec/web/asset_pipeline_spec.cr
+++ b/spec/web/asset_pipeline_spec.cr
@@ -2,9 +2,10 @@ require "./spec_helper"
 require "file_utils"
 
 describe AssetPipeline::FrontLoader do
-  Spec.after_each do
+  after_each do
     FileUtils.rm_rf("spec/test_output")
     FileUtils.mkdir("spec/test_output") unless File.exists?("spec/test_output")
+    File.write("spec/test_js/some_js.js", "// Here's some text for the comment\n\nconsole.log('test-modified-1783517887239');")
   end
 
   it "registers the default import map" do
@@ -130,9 +131,9 @@ describe AssetPipeline::FrontLoader do
     tmp_map.add_import("another_js", "another_js_file.js")
 
     front_loader = AssetPipeline::FrontLoader.new(
-      js_source_path: Path["spec/test_js"], 
-      js_output_path: Path["spec/test_output"]  # clear_cache_upon_change defaults to true
-    ) do |import_maps|
+      js_source_path: Path["spec/test_js"],
+      js_output_path: Path["spec/test_output"] # clear_cache_upon_change defaults to true
+) do |import_maps|
       import_maps << tmp_map
     end
 
@@ -156,9 +157,9 @@ describe AssetPipeline::FrontLoader do
 
     # Create new FrontLoader instance and regenerate (simulates cache clearing)
     new_front_loader = AssetPipeline::FrontLoader.new(
-      js_source_path: Path["spec/test_js"], 
-      js_output_path: Path["spec/test_output"]  # clear_cache_upon_change defaults to true
-    ) do |import_maps|
+      js_source_path: Path["spec/test_js"],
+      js_output_path: Path["spec/test_output"] # clear_cache_upon_change defaults to true
+) do |import_maps|
       new_map = AssetPipeline::ImportMap.new
       new_map.add_import("some_js", "some_js.js")
       new_map.add_import("another_js", "another_js_file.js")
@@ -201,10 +202,10 @@ describe AssetPipeline::FrontLoader do
     tmp_map.add_import("another_js", "another_js_file.js")
 
     front_loader = AssetPipeline::FrontLoader.new(
-      js_source_path: Path["spec/test_js"], 
+      js_source_path: Path["spec/test_js"],
       js_output_path: Path["spec/test_output"],
-      clear_cache_upon_change: false  # Disable cache clearing
-    ) do |import_maps|
+      clear_cache_upon_change: false # Disable cache clearing
+) do |import_maps|
       import_maps << tmp_map
     end
 
@@ -228,10 +229,10 @@ describe AssetPipeline::FrontLoader do
 
     # Create new FrontLoader instance and regenerate (without cache clearing)
     new_front_loader = AssetPipeline::FrontLoader.new(
-      js_source_path: Path["spec/test_js"], 
+      js_source_path: Path["spec/test_js"],
       js_output_path: Path["spec/test_output"],
-      clear_cache_upon_change: false  # Disable cache clearing
-    ) do |import_maps|
+      clear_cache_upon_change: false # Disable cache clearing
+) do |import_maps|
       new_map = AssetPipeline::ImportMap.new
       new_map.add_import("some_js", "some_js.js")
       new_map.add_import("another_js", "another_js_file.js")
@@ -253,10 +254,10 @@ describe AssetPipeline::FrontLoader do
 
     # Find files for the changed source
     some_js_files = final_files.select { |f| f.includes?("some_js-") }
-    
+
     # Should have at least the original file, possibly a new one if content changed enough to create new fingerprint
     some_js_files.size.should be >= 1
-    
+
     # The unchanged file should still only have one version (same fingerprint, no new generation needed)
     another_js_files = final_files.select { |f| f.includes?("another_js_file-") }
     another_js_files.size.should eq(1)

--- a/src/asset_pipeline.cr
+++ b/src/asset_pipeline.cr
@@ -13,7 +13,7 @@ require "./asset_pipeline/platform"
 
 # Top-level shard namespace housing FrontLoader, import maps, framework registry, and the cross-platform UI surface.
 module AssetPipeline
-  VERSION = "0.36.0"
+  VERSION = "0.37.0"
 
   # Initialize the framework registry with built-in framework support
   FrameworkRegistry.register_builtin_frameworks

--- a/src/asset_pipeline.cr
+++ b/src/asset_pipeline.cr
@@ -3,6 +3,7 @@
 
 require "digest/sha256"
 require "file_utils"
+require "./asset_pipeline/static_assets"
 require "./import_map/import_map"
 require "./asset_pipeline/dependency_analyzer"
 require "./asset_pipeline/script_renderer"

--- a/src/asset_pipeline/static_assets.cr
+++ b/src/asset_pipeline/static_assets.cr
@@ -1,0 +1,982 @@
+require "base64"
+require "compress/gzip"
+require "digest/sha256"
+require "file_utils"
+require "json"
+require "random/secure"
+require "uri"
+
+module AssetPipeline
+  # A deterministic, content-addressed compiler for application-owned web assets.
+  #
+  # Files are addressed by their normalized path relative to `source_root`.
+  # Builds preserve that directory structure, fingerprint every emitted file, and
+  # write a manifest suitable for runtime URL lookup. Text assets remain byte-for-
+  # byte identical except for local dependency URLs, which are rewritten to the
+  # dependency's fingerprinted public URL.
+  module StaticAssets
+    MANIFEST_SCHEMA_VERSION = 1
+    DEFAULT_MANIFEST_NAME   = "manifest.json"
+    FINGERPRINT_LENGTH      = 32
+
+    class Error < Exception
+    end
+
+    class ConfigurationError < Error
+    end
+
+    class MissingAssetError < Error
+      getter logical_path : String
+
+      def initialize(@logical_path : String, detail : String? = nil)
+        message = "Static asset '#{@logical_path}' was not found"
+        message += ": #{detail}" if detail
+        super(message)
+      end
+    end
+
+    class InvalidReferenceError < Error
+      getter source_path : String
+      getter reference : String
+
+      def initialize(@source_path : String, @reference : String, detail : String)
+        super("Invalid static asset reference '#{@reference}' in '#{@source_path}': #{detail}")
+      end
+    end
+
+    class VerificationError < Error
+    end
+
+    struct ManifestEntry
+      include JSON::Serializable
+
+      getter path : String
+      getter digest : String
+      getter integrity : String
+      getter content_type : String
+      getter bytes : Int64
+
+      def initialize(
+        @path : String,
+        @digest : String,
+        @integrity : String,
+        @content_type : String,
+        @bytes : Int64,
+      )
+      end
+    end
+
+    class Manifest
+      include JSON::Serializable
+
+      getter schema_version : Int32
+      getter public_path : String
+      getter assets : Hash(String, ManifestEntry)
+
+      def initialize(
+        @schema_version : Int32 = MANIFEST_SCHEMA_VERSION,
+        @public_path : String = "/assets",
+        @assets : Hash(String, ManifestEntry) = {} of String => ManifestEntry,
+      )
+      end
+
+      def self.load(file : Path | String) : self
+        path = file.to_s
+        raise ConfigurationError.new("Static asset manifest does not exist: #{path}") unless File.file?(path)
+
+        manifest = from_json(File.read(path))
+        unless manifest.schema_version == MANIFEST_SCHEMA_VERSION
+          raise ConfigurationError.new(
+            "Unsupported static asset manifest schema #{manifest.schema_version}; expected #{MANIFEST_SCHEMA_VERSION}"
+          )
+        end
+        manifest
+      rescue ex : JSON::SerializableError
+        raise ConfigurationError.new("Static asset manifest does not match schema (#{path}): #{ex.message}")
+      rescue ex : JSON::ParseException
+        raise ConfigurationError.new("Static asset manifest is invalid JSON (#{path}): #{ex.message}")
+      end
+
+      def entry(logical_path : Path | String) : ManifestEntry
+        logical = LogicalPath.normalize(logical_path.to_s)
+        @assets[logical]? || raise MissingAssetError.new(logical, "not present in the compiled manifest")
+      end
+
+      def path(logical_path : Path | String) : String
+        entry(logical_path).path
+      end
+
+      def integrity(logical_path : Path | String) : String
+        entry(logical_path).integrity
+      end
+
+      # Verifies that every manifest entry exists beneath *output_root* and
+      # still matches its byte count, SHA-256 digest, SRI value, MIME type, and
+      # expected precompressed representation.
+      def verify(output_root : Path | String) : Nil
+        root = Path[output_root.to_s].expand.normalize
+        @assets.keys.sort.each do |logical|
+          asset = @assets[logical]
+          normalized_logical = LogicalPath.normalize(logical)
+          unless asset.digest.matches?(/\A[a-f0-9]{64}\z/)
+            raise VerificationError.new("Static asset '#{normalized_logical}' has an invalid SHA-256 digest")
+          end
+          expected_path = expected_public_url(normalized_logical, asset.digest)
+          unless asset.path == expected_path
+            raise VerificationError.new(
+              "Static asset '#{normalized_logical}' has non-canonical path '#{asset.path}', expected '#{expected_path}'"
+            )
+          end
+          expected_type = MimeTypes.for(normalized_logical)
+          unless asset.content_type == expected_type
+            raise VerificationError.new(
+              "Static asset '#{normalized_logical}' has content type '#{asset.content_type}', expected '#{expected_type}'"
+            )
+          end
+
+          relative = relative_output_path(asset.path)
+          file = root.join(relative).normalize
+          unless within_root?(file, root)
+            raise VerificationError.new("Static asset '#{normalized_logical}' resolves outside output root")
+          end
+          unless File.file?(file)
+            raise VerificationError.new("Compiled static asset is missing: #{file}")
+          end
+
+          bytes = File.read(file).to_slice
+          digest = Digest::SHA256.hexdigest(bytes)
+          integrity = "sha256-#{Base64.strict_encode(Digest::SHA256.digest(bytes))}"
+          unless asset.bytes == bytes.size
+            raise VerificationError.new("Compiled static asset byte count changed: #{normalized_logical}")
+          end
+          unless asset.digest == digest
+            raise VerificationError.new("Compiled static asset digest changed: #{normalized_logical}")
+          end
+          unless asset.integrity == integrity
+            raise VerificationError.new("Compiled static asset integrity changed: #{normalized_logical}")
+          end
+          if MimeTypes.compressible?(asset.content_type)
+            gzip_file = "#{file}.gz"
+            unless File.file?(gzip_file)
+              raise VerificationError.new("Precompressed static asset is missing: #{gzip_file}")
+            end
+            begin
+              expanded = Compress::Gzip::Reader.open(gzip_file, &.gets_to_end)
+              unless expanded.to_slice == bytes
+                raise VerificationError.new("Precompressed static asset content changed: #{normalized_logical}")
+              end
+            rescue ex : Compress::Gzip::Error | Compress::Deflate::Error | IO::Error
+              raise VerificationError.new("Precompressed static asset is invalid: #{normalized_logical}: #{ex.message}")
+            end
+          end
+        end
+      end
+
+      def to_deterministic_json : String
+        String.build do |io|
+          JSON.build(io, indent: "  ") do |json|
+            json.object do
+              json.field "schema_version", @schema_version
+              json.field "public_path", @public_path
+              json.field "assets" do
+                json.object do
+                  @assets.keys.sort.each do |logical|
+                    asset = @assets[logical]
+                    json.field logical do
+                      json.object do
+                        json.field "path", asset.path
+                        json.field "digest", asset.digest
+                        json.field "integrity", asset.integrity
+                        json.field "content_type", asset.content_type
+                        json.field "bytes", asset.bytes
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private def relative_output_path(public_url : String) : String
+        normalized_public_path = normalized_public_path()
+        prefix = normalized_public_path == "/" ? "/" : "#{normalized_public_path}/"
+        unless public_url.starts_with?(prefix)
+          raise VerificationError.new("Manifest path is outside public path: #{public_url}")
+        end
+        LogicalPath.normalize(URI.decode(public_url[prefix.size..]))
+      rescue ex : URI::Error
+        raise VerificationError.new("Manifest path has invalid URL encoding: #{public_url}")
+      end
+
+      private def expected_public_url(logical : String, digest : String) : String
+        extension = File.extname(logical)
+        stem = extension.empty? ? logical : logical[0, logical.bytesize - extension.bytesize]
+        fingerprinted = "#{stem}-#{digest[0, FINGERPRINT_LENGTH]}#{extension}"
+        encoded = fingerprinted.split('/').map { |part| URI.encode_path_segment(part) }.join('/')
+        base = normalized_public_path()
+        base == "/" ? "/#{encoded}" : "#{base}/#{encoded}"
+      end
+
+      private def normalized_public_path : String
+        value = @public_path.strip
+        unless value.starts_with?('/') && !value.starts_with?("//") && !value.includes?('?') && !value.includes?('#')
+          raise VerificationError.new("Manifest public path must be a root-relative URL path")
+        end
+        value = value.gsub(/\/{2,}/, "/")
+        value = value.rstrip('/') unless value == "/"
+        value
+      end
+
+      private def within_root?(path : Path, root : Path) : Bool
+        relative = path.relative_to?(root)
+        return false unless relative
+        value = relative.to_s.gsub('\\', '/')
+        value != ".." && !value.starts_with?("../")
+      end
+    end
+
+    private module LogicalPath
+      extend self
+
+      def normalize(value : String) : String
+        normalized = value.gsub('\\', '/').strip
+        while normalized.starts_with?("./")
+          normalized = normalized[2..]
+        end
+
+        if normalized.empty? || normalized.starts_with?('/') || normalized.includes?('\0')
+          raise ConfigurationError.new("Invalid static asset logical path: #{value.inspect}")
+        end
+
+        parts = normalized.split('/')
+        if parts.any? { |part| part.empty? || part == "." || part == ".." }
+          raise ConfigurationError.new("Static asset logical path must not traverse directories: #{value.inspect}")
+        end
+        parts.join('/')
+      end
+
+      def from_path(path : Path, source_root : Path) : String
+        relative = path.relative_to?(source_root)
+        raise ConfigurationError.new("Static asset escaped source root: #{path}") unless relative
+        normalize(relative.to_s)
+      end
+    end
+
+    private struct SourceAsset
+      getter logical_path : String
+      getter path : Path
+
+      def initialize(@logical_path : String, @path : Path)
+      end
+    end
+
+    class Compiler
+      getter source_root : Path
+      getter output_root : Path
+      getter public_path : String
+      getter manifest_name : String
+      getter manifest : Manifest?
+
+      def initialize(
+        source_root : Path | String,
+        output_root : Path | String,
+        public_path : String = "/assets",
+        manifest_name : String = DEFAULT_MANIFEST_NAME,
+      )
+        @source_root = Path[source_root.to_s].expand.normalize
+        @output_root = Path[output_root.to_s].expand.normalize
+        @public_path = normalize_public_path(public_path)
+        @manifest_name = LogicalPath.normalize(manifest_name)
+        @manifest = nil
+        validate_configuration!
+      end
+
+      def self.load_manifest(
+        output_root : Path | String,
+        manifest_name : String = DEFAULT_MANIFEST_NAME,
+      ) : Manifest
+        Manifest.load(Path[output_root.to_s].join(LogicalPath.normalize(manifest_name)))
+      end
+
+      def self.check(
+        output_root : Path | String,
+        manifest_name : String = DEFAULT_MANIFEST_NAME,
+      ) : Manifest
+        manifest = load_manifest(output_root: output_root, manifest_name: manifest_name)
+        manifest.verify(output_root)
+        manifest
+      end
+
+      def build : Manifest
+        sources = discover_sources
+        emitted = compile_all(sources)
+        entries = {} of String => ManifestEntry
+
+        emitted.keys.sort.each do |logical|
+          bytes = emitted[logical]
+          digest = Digest::SHA256.hexdigest(bytes)
+          fingerprinted = fingerprinted_path(logical, digest)
+          entries[logical] = ManifestEntry.new(
+            path: public_url(fingerprinted),
+            digest: digest,
+            integrity: "sha256-#{Base64.strict_encode(Digest::SHA256.digest(bytes))}",
+            content_type: MimeTypes.for(logical),
+            bytes: bytes.size.to_i64,
+          )
+        end
+
+        new_manifest = Manifest.new(public_path: @public_path, assets: entries)
+        previous_manifest = load_previous_manifest
+        write_build(emitted, new_manifest)
+        prune_previous_build(previous_manifest, new_manifest)
+        @manifest = new_manifest
+        new_manifest
+      end
+
+      def entry(logical_path : Path | String) : ManifestEntry
+        current_manifest.entry(logical_path)
+      end
+
+      def asset_path(logical_path : Path | String) : String
+        current_manifest.path(logical_path)
+      end
+
+      def integrity(logical_path : Path | String) : String
+        current_manifest.integrity(logical_path)
+      end
+
+      def check : Manifest
+        checked = self.class.check(output_root: @output_root, manifest_name: @manifest_name)
+        @manifest = checked
+        checked
+      end
+
+      private def current_manifest : Manifest
+        @manifest || raise ConfigurationError.new("Static assets have not been built; call #build first")
+      end
+
+      private def validate_configuration! : Nil
+        unless Dir.exists?(@source_root)
+          raise ConfigurationError.new("Static asset source root does not exist: #{@source_root}")
+        end
+
+        source_real = Path[File.realpath(@source_root)]
+        output_parent = nearest_existing_parent(@output_root)
+        output_real = Path[File.realpath(output_parent)].join(@output_root.relative_to(output_parent)).normalize
+
+        if within?(output_real, source_real)
+          raise ConfigurationError.new("Static asset output root must not be inside source root")
+        end
+        if within?(source_real, output_real)
+          raise ConfigurationError.new("Static asset source root must not be inside output root")
+        end
+      end
+
+      private def discover_sources : Hash(String, SourceAsset)
+        source_real = Path[File.realpath(@source_root)]
+        result = {} of String => SourceAsset
+
+        Dir.glob(@source_root.join("**", "*").to_s).sort.each do |file_name|
+          next if File.directory?(file_name)
+
+          file_path = Path[file_name].expand.normalize
+          logical = LogicalPath.from_path(file_path, @source_root)
+          next if hidden_logical_path?(logical)
+
+          real_path = Path[File.realpath(file_path)]
+          unless within?(real_path, source_real)
+            raise ConfigurationError.new("Static asset symlink escapes source root: #{logical}")
+          end
+
+          if result.has_key?(logical)
+            raise ConfigurationError.new("Duplicate static asset logical path: #{logical}")
+          end
+          result[logical] = SourceAsset.new(logical, real_path)
+        end
+        result
+      end
+
+      private def hidden_logical_path?(logical : String) : Bool
+        logical.split('/').any?(&.starts_with?('.'))
+      end
+
+      private def compile_all(sources : Hash(String, SourceAsset)) : Hash(String, Bytes)
+        emitted = {} of String => Bytes
+        states = {} of String => Symbol
+
+        sources.keys.sort.each do |logical|
+          compile_asset(logical, sources, emitted, states)
+        end
+        emitted
+      end
+
+      private def compile_asset(
+        logical : String,
+        sources : Hash(String, SourceAsset),
+        emitted : Hash(String, Bytes),
+        states : Hash(String, Symbol),
+      ) : Bytes
+        return emitted[logical] if emitted.has_key?(logical)
+        if states[logical]? == :visiting
+          raise InvalidReferenceError.new(logical, logical, "dependency cycle detected")
+        end
+
+        source = sources[logical]? || raise MissingAssetError.new(logical)
+        states[logical] = :visiting
+        original = File.read(source.path).to_slice.dup
+        extension = File.extname(logical).downcase
+
+        compiled = case extension
+                   when ".css"
+                     rewrite_css(String.new(original), logical, sources, emitted, states).to_slice.dup
+                   when ".js", ".mjs", ".cjs"
+                     rewrite_javascript(String.new(original), logical, sources, emitted, states).to_slice.dup
+                   else
+                     original
+                   end
+
+        states[logical] = :done
+        emitted[logical] = compiled
+      rescue ex : ArgumentError
+        raise Error.new("Text asset '#{logical}' is not valid UTF-8: #{ex.message}")
+      end
+
+      private def rewrite_css(
+        contents : String,
+        source_logical : String,
+        sources : Hash(String, SourceAsset),
+        emitted : Hash(String, Bytes),
+        states : Hash(String, Symbol),
+      ) : String
+        bytes = contents.to_slice
+        replacements = [] of Tuple(Int32, Int32, String)
+        index = 0
+
+        while index < bytes.size
+          byte = bytes[index]
+          if byte == '/'.ord && bytes[index + 1]? == '*'.ord
+            index = skip_block_comment(bytes, index)
+          elsif quote_byte?(byte)
+            index = skip_quoted(bytes, index)
+          elsif css_word_at?(bytes, index, "url")
+            if range = css_url_reference_range(bytes, index)
+              start_index, end_index, after_index = range
+              reference = contents.byte_slice(start_index, end_index - start_index)
+              target = rewrite_reference(reference, source_logical, sources, emitted, states)
+              replacements << {start_index, end_index, target} unless target == reference
+              index = after_index
+            else
+              index += 1
+            end
+          elsif css_word_at?(bytes, index, "@import")
+            if range = css_import_reference_range(bytes, index)
+              start_index, end_index, after_index = range
+              reference = contents.byte_slice(start_index, end_index - start_index)
+              target = rewrite_reference(reference, source_logical, sources, emitted, states)
+              replacements << {start_index, end_index, target} unless target == reference
+              index = after_index
+            else
+              index += 1
+            end
+          else
+            index += 1
+          end
+        end
+
+        apply_replacements(contents, replacements)
+      end
+
+      private def rewrite_javascript_import_reference(
+        reference : String,
+        source_logical : String,
+        sources : Hash(String, SourceAsset),
+        emitted : Hash(String, Bytes),
+        states : Hash(String, Symbol),
+      ) : String
+        return reference unless reference.starts_with?("./") || reference.starts_with?("../")
+        rewrite_reference(reference, source_logical, sources, emitted, states)
+      end
+
+      private def rewrite_javascript(
+        contents : String,
+        source_logical : String,
+        sources : Hash(String, SourceAsset),
+        emitted : Hash(String, Bytes),
+        states : Hash(String, Symbol),
+      ) : String
+        bytes = contents.to_slice
+        replacements = [] of Tuple(Int32, Int32, String)
+        index = 0
+
+        while index < bytes.size
+          byte = bytes[index]
+          if byte == '/'.ord && bytes[index + 1]? == '/'.ord
+            line_end = index + 2
+            while line_end < bytes.size && bytes[line_end] != '\n'.ord
+              line_end += 1
+            end
+            comment = contents.byte_slice(index, line_end - index)
+            if match = comment.match(/\A\/\/[#@]\s*sourceMappingURL=([^\s]+)/)
+              start_index = index + match.byte_begin(1)
+              end_index = index + match.byte_end(1)
+              reference = match[1]
+              target = rewrite_reference(reference, source_logical, sources, emitted, states)
+              replacements << {start_index, end_index, target} unless target == reference
+            end
+            index = line_end
+          elsif byte == '/'.ord && bytes[index + 1]? == '*'.ord
+            index = skip_block_comment(bytes, index)
+          elsif quote_byte?(byte) || byte == '`'.ord
+            index = skip_quoted(bytes, index)
+          elsif js_keyword_at?(bytes, index, "import")
+            if range = javascript_module_reference_range(bytes, index, "import")
+              start_index, end_index, after_index = range
+              reference = contents.byte_slice(start_index, end_index - start_index)
+              target = rewrite_javascript_import_reference(reference, source_logical, sources, emitted, states)
+              replacements << {start_index, end_index, target} unless target == reference
+              index = after_index
+            else
+              index += "import".bytesize
+            end
+          elsif js_keyword_at?(bytes, index, "export")
+            if range = javascript_module_reference_range(bytes, index, "export")
+              start_index, end_index, after_index = range
+              reference = contents.byte_slice(start_index, end_index - start_index)
+              target = rewrite_javascript_import_reference(reference, source_logical, sources, emitted, states)
+              replacements << {start_index, end_index, target} unless target == reference
+              index = after_index
+            else
+              index += "export".bytesize
+            end
+          else
+            index += 1
+          end
+        end
+
+        apply_replacements(contents, replacements)
+      end
+
+      private def css_url_reference_range(bytes : Bytes, word_start : Int32) : Tuple(Int32, Int32, Int32)?
+        index = skip_ascii_space(bytes, word_start + 3)
+        return unless bytes[index]? == '('.ord
+        index = skip_ascii_space(bytes, index + 1)
+
+        if quote = bytes[index]?
+          if quote_byte?(quote)
+            end_index = quoted_content_end(bytes, index)
+            return unless end_index
+            after_index = skip_ascii_space(bytes, end_index + 1)
+            return unless bytes[after_index]? == ')'.ord
+            return {index + 1, end_index, after_index + 1}
+          end
+        end
+
+        start_index = index
+        while index < bytes.size && bytes[index] != ')'.ord
+          index += bytes[index] == '\\'.ord && index + 1 < bytes.size ? 2 : 1
+        end
+        return if index >= bytes.size
+
+        end_index = index
+        while start_index < end_index && ascii_space?(bytes[start_index])
+          start_index += 1
+        end
+        while end_index > start_index && ascii_space?(bytes[end_index - 1])
+          end_index -= 1
+        end
+        {start_index, end_index, index + 1}
+      end
+
+      private def css_import_reference_range(bytes : Bytes, word_start : Int32) : Tuple(Int32, Int32, Int32)?
+        index = skip_ascii_space(bytes, word_start + "@import".bytesize)
+        quote = bytes[index]?
+        return unless quote && quote_byte?(quote)
+        end_index = quoted_content_end(bytes, index)
+        return unless end_index
+        {index + 1, end_index, end_index + 1}
+      end
+
+      private def javascript_module_reference_range(
+        bytes : Bytes,
+        keyword_start : Int32,
+        keyword : String,
+      ) : Tuple(Int32, Int32, Int32)?
+        index = skip_ascii_space(bytes, keyword_start + keyword.bytesize)
+
+        if keyword == "import" && bytes[index]? == '('.ord
+          index = skip_ascii_space(bytes, index + 1)
+          return quoted_reference_range(bytes, index)
+        end
+
+        if keyword == "import" && (quote = bytes[index]?) && quote_byte?(quote)
+          return quoted_reference_range(bytes, index)
+        end
+
+        while index < bytes.size
+          byte = bytes[index]
+          if byte == ';'.ord
+            return
+          elsif byte == '/'.ord && bytes[index + 1]? == '/'.ord
+            index += 2
+            while index < bytes.size && bytes[index] != '\n'.ord
+              index += 1
+            end
+          elsif byte == '/'.ord && bytes[index + 1]? == '*'.ord
+            index = skip_block_comment(bytes, index)
+          elsif quote_byte?(byte) || byte == '`'.ord
+            index = skip_quoted(bytes, index)
+          elsif js_keyword_at?(bytes, index, "from")
+            reference_start = skip_ascii_space(bytes, index + "from".bytesize)
+            return quoted_reference_range(bytes, reference_start)
+          else
+            index += 1
+          end
+        end
+        nil
+      end
+
+      private def quoted_reference_range(bytes : Bytes, quote_index : Int32) : Tuple(Int32, Int32, Int32)?
+        quote = bytes[quote_index]?
+        return unless quote && quote_byte?(quote)
+        end_index = quoted_content_end(bytes, quote_index)
+        return unless end_index
+        {quote_index + 1, end_index, end_index + 1}
+      end
+
+      private def quoted_content_end(bytes : Bytes, quote_index : Int32) : Int32?
+        quote = bytes[quote_index]
+        index = quote_index + 1
+        while index < bytes.size
+          if bytes[index] == '\\'.ord
+            index += 2
+          elsif bytes[index] == quote
+            return index
+          else
+            index += 1
+          end
+        end
+        nil
+      end
+
+      private def skip_quoted(bytes : Bytes, quote_index : Int32) : Int32
+        end_index = quoted_content_end(bytes, quote_index)
+        end_index ? end_index + 1 : bytes.size
+      end
+
+      private def skip_block_comment(bytes : Bytes, comment_start : Int32) : Int32
+        index = comment_start + 2
+        while index + 1 < bytes.size
+          return index + 2 if bytes[index] == '*'.ord && bytes[index + 1] == '/'.ord
+          index += 1
+        end
+        bytes.size
+      end
+
+      private def skip_ascii_space(bytes : Bytes, start_index : Int32) : Int32
+        index = start_index
+        while index < bytes.size && ascii_space?(bytes[index])
+          index += 1
+        end
+        index
+      end
+
+      private def ascii_space?(byte : UInt8) : Bool
+        byte == ' '.ord || byte == '\t'.ord || byte == '\n'.ord || byte == '\r'.ord || byte == '\f'.ord
+      end
+
+      private def quote_byte?(byte : UInt8) : Bool
+        byte == '\''.ord || byte == '"'.ord
+      end
+
+      private def identifier_byte?(byte : UInt8) : Bool
+        (byte >= 'a'.ord && byte <= 'z'.ord) ||
+          (byte >= 'A'.ord && byte <= 'Z'.ord) ||
+          (byte >= '0'.ord && byte <= '9'.ord) ||
+          byte == '_'.ord || byte == '-'.ord || byte == '$'.ord
+      end
+
+      private def css_word_at?(bytes : Bytes, index : Int32, word : String) : Bool
+        return false if index > 0 && identifier_byte?(bytes[index - 1])
+        return false if index + word.bytesize > bytes.size
+        word.to_slice.each_with_index do |expected, offset|
+          actual = bytes[index + offset]
+          return false unless ascii_downcase(actual) == ascii_downcase(expected)
+        end
+        after = bytes[index + word.bytesize]?
+        !after || !identifier_byte?(after)
+      end
+
+      private def js_keyword_at?(bytes : Bytes, index : Int32, keyword : String) : Bool
+        return false if index > 0 && (identifier_byte?(bytes[index - 1]) || bytes[index - 1] == '.'.ord)
+        return false if index + keyword.bytesize > bytes.size
+        keyword.to_slice.each_with_index do |expected, offset|
+          return false unless bytes[index + offset] == expected
+        end
+        after = bytes[index + keyword.bytesize]?
+        !after || !identifier_byte?(after)
+      end
+
+      private def ascii_downcase(byte : UInt8) : UInt8
+        byte >= 'A'.ord && byte <= 'Z'.ord ? byte + 32 : byte
+      end
+
+      private def apply_replacements(
+        contents : String,
+        replacements : Array(Tuple(Int32, Int32, String)),
+      ) : String
+        return contents if replacements.empty?
+        String.build do |io|
+          cursor = 0
+          replacements.sort_by(&.[0]).each do |start_index, end_index, replacement|
+            io << contents.byte_slice(cursor, start_index - cursor)
+            io << replacement
+            cursor = end_index
+          end
+          io << contents.byte_slice(cursor, contents.bytesize - cursor)
+        end
+      end
+
+      private def rewrite_reference(
+        raw_reference : String,
+        source_logical : String,
+        sources : Hash(String, SourceAsset),
+        emitted : Hash(String, Bytes),
+        states : Hash(String, Symbol),
+      ) : String
+        return raw_reference if external_reference?(raw_reference)
+
+        path_part, suffix = split_reference(raw_reference)
+        return raw_reference if path_part.empty?
+
+        target_logical = resolve_reference(source_logical, path_part)
+        unless sources.has_key?(target_logical)
+          raise InvalidReferenceError.new(source_logical, raw_reference, "target '#{target_logical}' does not exist")
+        end
+
+        dependency_bytes = compile_asset(target_logical, sources, emitted, states)
+        digest = Digest::SHA256.hexdigest(dependency_bytes)
+        public_url(fingerprinted_path(target_logical, digest)) + suffix
+      end
+
+      private def resolve_reference(source_logical : String, reference_path : String) : String
+        decoded = URI.decode(reference_path)
+        candidate = Path[source_logical].parent.join(decoded).normalize
+        candidate_string = candidate.to_s.gsub('\\', '/')
+        if candidate.absolute? || candidate_string == ".." || candidate_string.starts_with?("../")
+          raise InvalidReferenceError.new(source_logical, reference_path, "reference escapes source root")
+        end
+        LogicalPath.normalize(candidate_string)
+      rescue ex : URI::Error
+        raise InvalidReferenceError.new(source_logical, reference_path, "invalid URL encoding")
+      end
+
+      private def external_reference?(reference : String) : Bool
+        value = reference.strip
+        value.empty? ||
+          value.starts_with?('#') ||
+          value.starts_with?('/') ||
+          value.starts_with?("//") ||
+          value.starts_with?(/(?i:data|https?|blob|mailto|tel):/)
+      end
+
+      private def split_reference(reference : String) : {String, String}
+        if index = reference.index(/[?#]/)
+          {reference[0, index], reference[index..]}
+        else
+          {reference, ""}
+        end
+      end
+
+      private def write_build(emitted : Hash(String, Bytes), manifest : Manifest) : Nil
+        Dir.mkdir_p(@output_root)
+
+        emitted.keys.sort.each do |logical|
+          entry = manifest.assets[logical]
+          output_file = output_path_for_public_url(entry.path)
+          atomic_write(output_file, emitted[logical])
+          write_gzip(output_file, emitted[logical]) if MimeTypes.compressible?(entry.content_type)
+        end
+
+        atomic_write(@output_root.join(@manifest_name), manifest.to_deterministic_json.to_slice)
+      end
+
+      private def load_previous_manifest : Manifest?
+        path = @output_root.join(@manifest_name)
+        return nil unless File.file?(path)
+        Manifest.load(path)
+      end
+
+      private def prune_previous_build(previous : Manifest?, current : Manifest) : Nil
+        return unless previous
+        # A changed public mount cannot be mapped back to this output root safely.
+        # Leave those old files alone rather than guessing what the application owns.
+        return unless previous.public_path == @public_path
+        current_paths = current.assets.values.map(&.path).to_set
+
+        previous.assets.each do |logical, entry|
+          next if current_paths.includes?(entry.path)
+          next unless compiler_owned_entry?(logical, entry)
+          remove_owned_file(entry.path)
+        end
+        remove_empty_directories(@output_root)
+      end
+
+      private def compiler_owned_entry?(logical : String, entry : ManifestEntry) : Bool
+        return false unless entry.digest.matches?(/\A[a-f0-9]{64}\z/)
+        normalized = LogicalPath.normalize(logical)
+        entry.path == public_url(fingerprinted_path(normalized, entry.digest))
+      rescue ConfigurationError
+        false
+      end
+
+      private def remove_owned_file(public_url : String) : Nil
+        path = output_path_for_public_url(public_url)
+        File.delete(path) if File.file?(path)
+        gzip_path = Path["#{path}.gz"]
+        File.delete(gzip_path) if File.file?(gzip_path)
+      end
+
+      private def output_path_for_public_url(public_url : String) : Path
+        prefix = @public_path == "/" ? "/" : "#{@public_path}/"
+        unless public_url.starts_with?(prefix)
+          raise ConfigurationError.new("Manifest path is outside configured public path: #{public_url}")
+        end
+        logical = URI.decode(public_url[prefix.size..])
+        @output_root.join(LogicalPath.normalize(logical)).normalize
+      rescue ex : URI::Error
+        raise ConfigurationError.new("Manifest path has invalid URL encoding: #{public_url}")
+      end
+
+      private def atomic_write(path : Path, bytes : Bytes) : Nil
+        Dir.mkdir_p(path.parent)
+        temporary = path.parent.join(".#{path.basename}.tmp-#{Process.pid}-#{Random::Secure.hex(8)}")
+        begin
+          File.open(temporary, "wb") do |file|
+            file.write(bytes)
+            file.flush
+          end
+          File.rename(temporary, path)
+        ensure
+          File.delete(temporary) if File.exists?(temporary)
+        end
+      end
+
+      private def write_gzip(path : Path, bytes : Bytes) : Nil
+        temporary = path.parent.join(".#{path.basename}.gz.tmp-#{Process.pid}-#{Random::Secure.hex(8)}")
+        begin
+          File.open(temporary, "wb") do |file|
+            writer = Compress::Gzip::Writer.new(file)
+            writer.header.modification_time = Time.unix(0)
+            writer.write(bytes)
+            writer.close
+          end
+          File.rename(temporary, "#{path}.gz")
+        ensure
+          File.delete(temporary) if File.exists?(temporary)
+        end
+      end
+
+      private def fingerprinted_path(logical : String, digest : String) : String
+        extension = File.extname(logical)
+        stem = extension.empty? ? logical : logical[0, logical.bytesize - extension.bytesize]
+        "#{stem}-#{digest[0, FINGERPRINT_LENGTH]}#{extension}"
+      end
+
+      private def public_url(logical : String) : String
+        encoded = logical.split('/').map { |part| URI.encode_path_segment(part) }.join('/')
+        @public_path == "/" ? "/#{encoded}" : "#{@public_path}/#{encoded}"
+      end
+
+      private def normalize_public_path(path : String) : String
+        value = path.strip
+        unless value.starts_with?('/') && !value.starts_with?("//") && !value.includes?('?') && !value.includes?('#')
+          raise ConfigurationError.new("Static asset public path must be a root-relative URL path")
+        end
+        value = value.gsub(/\/{2,}/, "/")
+        value = value.rstrip('/') unless value == "/"
+        value
+      end
+
+      private def nearest_existing_parent(path : Path) : Path
+        current = path
+        until File.exists?(current)
+          parent = current.parent
+          raise ConfigurationError.new("Could not resolve output root: #{path}") if parent == current
+          current = parent
+        end
+        current
+      end
+
+      private def within?(path : Path, root : Path) : Bool
+        relative = path.relative_to?(root)
+        return false unless relative
+        relative_string = relative.to_s.gsub('\\', '/')
+        relative_string != ".." && !relative_string.starts_with?("../")
+      end
+
+      private def remove_empty_directories(root : Path) : Nil
+        return unless Dir.exists?(root)
+        directories = Dir.glob(root.join("**", "*").to_s).select { |path| File.directory?(path) }
+        directories.sort_by(&.size).reverse_each do |directory|
+          Dir.delete(directory) if Dir.empty?(directory)
+        end
+      end
+    end
+
+    private module MimeTypes
+      extend self
+
+      TYPES = {
+        ".css"         => "text/css; charset=utf-8",
+        ".js"          => "text/javascript; charset=utf-8",
+        ".mjs"         => "text/javascript; charset=utf-8",
+        ".cjs"         => "text/javascript; charset=utf-8",
+        ".map"         => "application/json; charset=utf-8",
+        ".json"        => "application/json; charset=utf-8",
+        ".webmanifest" => "application/manifest+json; charset=utf-8",
+        ".xml"         => "application/xml; charset=utf-8",
+        ".txt"         => "text/plain; charset=utf-8",
+        ".html"        => "text/html; charset=utf-8",
+        ".htm"         => "text/html; charset=utf-8",
+        ".csv"         => "text/csv; charset=utf-8",
+        ".svg"         => "image/svg+xml",
+        ".png"         => "image/png",
+        ".jpg"         => "image/jpeg",
+        ".jpeg"        => "image/jpeg",
+        ".gif"         => "image/gif",
+        ".webp"        => "image/webp",
+        ".avif"        => "image/avif",
+        ".ico"         => "image/x-icon",
+        ".woff"        => "font/woff",
+        ".woff2"       => "font/woff2",
+        ".ttf"         => "font/ttf",
+        ".otf"         => "font/otf",
+        ".eot"         => "application/vnd.ms-fontobject",
+        ".pdf"         => "application/pdf",
+        ".zip"         => "application/zip",
+        ".wasm"        => "application/wasm",
+        ".mp3"         => "audio/mpeg",
+        ".ogg"         => "audio/ogg",
+        ".wav"         => "audio/wav",
+        ".mp4"         => "video/mp4",
+        ".webm"        => "video/webm",
+      }
+
+      def for(path : String) : String
+        TYPES[File.extname(path).downcase]? || "application/octet-stream"
+      end
+
+      def compressible?(content_type : String) : Bool
+        media_type = content_type.split(';', 2).first
+        media_type.starts_with?("text/") ||
+          media_type == "application/json" ||
+          media_type.ends_with?("+json") ||
+          media_type == "application/xml" ||
+          media_type == "image/svg+xml" ||
+          media_type == "application/wasm"
+      end
+    end
+  end
+end

--- a/src/asset_pipeline/static_assets.cr
+++ b/src/asset_pipeline/static_assets.cr
@@ -378,7 +378,7 @@ module AssetPipeline
         source_real = Path[File.realpath(@source_root)]
         result = {} of String => SourceAsset
 
-        Dir.glob(@source_root.join("**", "*").to_s).sort.each do |file_name|
+        Dir.glob(glob_pattern(@source_root.join("**", "*"))).sort.each do |file_name|
           next if File.directory?(file_name)
 
           file_path = Path[file_name].expand.normalize
@@ -918,10 +918,18 @@ module AssetPipeline
 
       private def remove_empty_directories(root : Path) : Nil
         return unless Dir.exists?(root)
-        directories = Dir.glob(root.join("**", "*").to_s).select { |path| File.directory?(path) }
+        directories = Dir.glob(glob_pattern(root.join("**", "*"))).select { |path| File.directory?(path) }
         directories.sort_by(&.size).reverse_each do |directory|
           Dir.delete(directory) if Dir.empty?(directory)
         end
+      end
+
+      # Crystal's `Path#to_s` uses backslashes on Windows, while `Dir.glob`
+      # expects forward-slash separators in its pattern on every platform.
+      # Normalizing only the glob expression keeps filesystem paths native and
+      # lets generated applications discover their authored assets on Windows.
+      private def glob_pattern(path : Path) : String
+        path.to_s.gsub('\\', '/')
       end
     end
 


### PR DESCRIPTION
## What ships

- recursively fingerprints images, fonts, CSS, JavaScript, and other static files
- rewrites local CSS URLs and JavaScript module references to their fingerprinted outputs
- writes a deterministic manifest with integrity, content type, byte size, and precompressed gzip metadata
- verifies generated output and safely prunes only files owned by the previous manifest
- documents the supported compiler contract for `asset_pipeline` 0.37.0
- runs the full web suite on Linux and macOS with Crystal 1.10.1 and latest

## Validation

- `make test-web`: 2,071 examples, 0 failures, 66 pending
- `git diff --check`

This replaces #13, whose branch included unrelated native-development history.
